### PR TITLE
Fix format strings in Italian translation

### DIFF
--- a/content/it/cuba/modules/global/src/com/haulmont/cuba/messages_it.properties
+++ b/content/it/cuba/modules/global/src/com/haulmont/cuba/messages_it.properties
@@ -250,10 +250,10 @@ com.haulmont.cuba.core.global.validation/org.hibernate.validator.constraints.Scr
 com.haulmont.cuba.core.global.validation/org.hibernate.validator.constraints.URL.message=deve essere un URL valido
 dateFormat=dd/MM/yyyy
 dateTimeFormat=dd/MM/yyyy HH:mm
-decimalFormat=#.##0,##
-doubleFormat=#.##0,###
+decimalFormat=#,##0.##
+doubleFormat=#,##0.###
 falseString=Falso
-integerFormat=#.##0
+integerFormat=#,##0
 numberDecimalSeparator=,
 numberGroupingSeparator=.
 timeFormat=HH:mm


### PR DESCRIPTION
This fixes `java.lang.IllegalArgumentException: Malformed pattern` exceptions.. sorry for that, don't know how I could've missed this so far! :/